### PR TITLE
Update OWASP top ten to 2013 version

### DIFF
--- a/src/pages/hashing-security.php
+++ b/src/pages/hashing-security.php
@@ -692,7 +692,7 @@ Even experienced developers must be educated in security in order to write secur
 A great resource for learning about web application vulnerabilities is 
 <a href="https://www.owasp.org/index.php/Main_Page">The Open Web Application
 Security Project (OWASP)</a>. A good introduction is the 
-<a href="http://owasptop10.googlecode.com/files/OWASP%20Top%2010%20-%202010.pdf">OWASP Top Ten Vulnerability List</a>.
+<a href="http://owasptop10.googlecode.com/files/OWASP%20Top%2010%20-%202013.pdf">OWASP Top Ten Vulnerability List</a>.
 Unless you understand all the vulnerabilities on the list, do not attempt to
 write a web application that deals with sensitive data. It is the employer's
 responsibility to ensure all developers are adequately trained in secure


### PR DESCRIPTION
The link to the OWAST top ten vulnerability list is outdated.
